### PR TITLE
ENG-627 disable SharedArrayBuffer in ffprobe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN cd /tmp/x264-snapshot-${X264_VERSION} && \
   --enable-static \
   --disable-cli \
   --disable-asm \
-  --extra-cflags="-s USE_PTHREADS=1"
+  --extra-cflags="-s USE_PTHREADS=0"
 
 RUN cd /tmp/x264-snapshot-${X264_VERSION} && \
   emmake make && emmake make install 
@@ -36,7 +36,8 @@ RUN cd /tmp/lame-${LAME_VERSION} && \
   --prefix=${PREFIX} \
   --host=i686-gnu \
   --enable-static \
-  --disable-frontend
+  --disable-frontend \
+  --extra-cflags="-s USE_PTHREADS=0"
 
 RUN cd /tmp/lame-${LAME_VERSION} && \
   emmake make && emmake make install 
@@ -46,7 +47,7 @@ RUN cd /tmp/ && \
   wget http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz && \
   tar zxf ffmpeg-${FFMPEG_VERSION}.tar.gz && rm ffmpeg-${FFMPEG_VERSION}.tar.gz
 
-ARG CFLAGS="-s USE_PTHREADS=1 -O3 -I${PREFIX}/include"
+ARG CFLAGS="-s USE_PTHREADS=0 -O3 -I${PREFIX}/include"
 ARG LDFLAGS="$CFLAGS -L${PREFIX}/lib -s INITIAL_MEMORY=33554432"
 
 # Compile ffmpeg.

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@ dist/ffprobe-wasm.js:
 	-s EXTRA_EXPORTED_RUNTIME_METHODS="[FS, cwrap, ccall, getValue, setValue, writeAsciiToMemory]" \
 	-s INITIAL_MEMORY=268435456 \
 	-lavcodec -lavformat -lavfilter -lavdevice -lswresample -lswscale -lavutil -lm -lx264 \
-	-pthread \
 	-lworkerfs.js \
 	-o dist/ffprobe-wasm.js \
 	src/ffprobe-wasm-wrapper.cpp && \
-	cp www/public/ffprobe-worker.js dist/
+	cp ../www/public/ffprobe-worker.js dist/


### PR DESCRIPTION
# Summary of code changes
- [ ] disables pthreads

## Result
No longer requires SharedArrayBuffer to function

## Manual testing (QA)
1. Visit <preview_deploy>.filmhub.com
2. 

## It works on my machine
_Attach screenshots/video_

|before|after|
|--|--|
|_replace_with_before_file.png_|_replace_with_after_file.png_|

# Ready for Review Checklist
- [ ] New javascript files are written with TypeScript
- [ ] All deliverables in Linear issue are checked off
- [ ] Touched code uses [documented patterns](https://www.notion.so/filmhub/Code-patterns-style-guide-944c3fa9d8f04035a298ad5684cea007?pvs=4)
- [ ] Integration tests follow [documented best practices](https://www.notion.so/filmhub/Testing-Best-Practices-c9d1a43b5fea4c6c94465728e18ba35c?pvs=4)

---

# Reviewing this PR
Use [Conventional Comments](https://conventionalcomments.org/) when leaving PR feedback.

`<label> (<(non-)blocking>): <note>`

## Standard labels
|--|use case|
|--|--|
|nit|Minor change request|
|actionable|Major change request|
|discussion|Question or commentary|

Examples:

`nit (non-blocking): convert function signature to options object rather than named parameters`

`nit (blocking): use [naming convention](<link to Notion>) on this function`
